### PR TITLE
Add get_reason function to privacy provider

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -19,4 +19,13 @@ namespace availability_days\privacy;
 defined('MOODLE_INTERNAL') || die();
 
 class provider implements \core_privacy\local\metadata\null_provider {
+    /**
+     * Get the language string identifier with the component's language
+     * file to explain why this plugin stores no data.
+     *
+     * @return  string
+     */
+    public static function get_reason() : string {
+        return 'privacy:metadata';
+    }
 }


### PR DESCRIPTION
Hi Valery,

It appears that your implementation of the privacy null provider is incomplete on the following branches:

MOODLE_34_STABLE
MOODLE_34_WORKING
MOODLE_35_STABLE
It is correct on all of the 36 branches, and the 35 WORKING branch.

Reported on Moodle forums at https://moodle.org/mod/forum/discuss.php?d=380502